### PR TITLE
Fix python syntaxerror non ascii character xe2 in file

### DIFF
--- a/Wifi-Hacking.py
+++ b/Wifi-Hacking.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 #!/usr/bin/env python
 import os
 import subprocess


### PR DESCRIPTION
Im run kali wsl and get error "python syntaxerror non ascii character xe2 in file" and try fix!